### PR TITLE
Update to Ubuntu Focal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 ## CONFIGURATION ##
 NAME=img/mines-cs-vm.vmdk
-FORMAT=VMDK
+FORMAT=vmdk
 NBD=/dev/nbd0
 
 SIZE=$(shell echo "15 * 2^30" | bc)
@@ -13,7 +13,7 @@ PARTITION=$(NBD)p1
 IMAGE_MOUNT=imgfs
 
 DEB_BASE=ubuntu
-DEB_DIST=xenial
+DEB_DIST=focal
 DEB_DIST_DIR=$(DEB_DIST)
 DEB_URL=http://archive.ubuntu.com/ubuntu/
 DEB_TARBALL=$(DEB_DIST).tgz
@@ -23,7 +23,7 @@ VMHOSTNAME=minesvm
 VBOXVM=minesvm
 
 DOCKER_TAG_REPO=mines-cs-vm
-DOCKER_TAG_SEMESTER=F2018
+DOCKER_TAG_SEMESTER=F2020
 DOCKER_TAG_VERSION=a0
 
 UPLOAD_HOST=isengard-jump
@@ -69,10 +69,15 @@ docker-shell:
 ## DISK IMAGE and FILESYSTEM ##
 
 base.vmdk:
-	vbox-img createbase \
-		--filename $@ \
-		--format "$(FORMAT)" \
-		--size "$(SIZE)"
+	qemu-img create \
+		-f $(FORMAT) \
+		$@ \
+		$(SIZE)
+
+	# vbox-img createbase \
+	# 	--filename $@ \
+	# 	--format "$(FORMAT)" \
+	# 	--size "$(SIZE)"
 
 
 partition.vmdk: base.vmdk
@@ -139,7 +144,7 @@ vmfinish:
 		-e 's/^GRUB_TIMEOUT=.*/GRUB_TIMEOUT=3/' \
 		-e 's/^GRUB_CMDLINE_LINUX_DEFAULT=.*/GRUB_CMDLINE_LINUX_DEFAULT=""/' \
 		$(IMAGE_MOUNT)/etc/default/grub
-	chroot $(IMAGE_MOUNT) update-grub2
+	chroot $(IMAGE_MOUNT) update-grub
 
 umount:
 	umount -R $(IMAGE_MOUNT)
@@ -149,12 +154,12 @@ $(NAME).bz2: $(NAME)
 	lbzip2 -k $<
 
 
-.PHONY: upload
-upload: $(NAME)
-	xz -9 -T 0 -vck $< | \
-		ssh -o compression=no \
-			$(UPLOAD_HOST) \
-			 "cat > $(UPLOAD_PATH)/$(notdir $(NAME)).xz"
+# .PHONY: upload
+# upload: $(NAME)
+# 	xz -9 -T 0 -vck $< | \
+# 		ssh -o compression=no \
+# 			$(UPLOAD_HOST) \
+# 			 "cat > $(UPLOAD_PATH)/$(notdir $(NAME)).xz"
 
 
 

--- a/guest/packages
+++ b/guest/packages
@@ -1,6 +1,7 @@
 grub2
+grub-pc
 linux-image-generic
 sudo
 build-essential
-emacs24
+emacs
 sbcl

--- a/script/lispgrader
+++ b/script/lispgrader
@@ -1,4 +1,4 @@
-FROM mines-cs-vm:F2018-a0
+FROM mines-cs-vm:F2020-a0
 
 USER blaster
 

--- a/script/ubuntu-focal
+++ b/script/ubuntu-focal
@@ -1,0 +1,60 @@
+FROM ubuntu:focal
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get -y update
+
+# basic setup
+RUN apt-get -y update && apt-get install -y  \
+    sudo \
+    locales  \
+    && \
+    locale-gen en_US.UTF-8
+
+# Desktop
+RUN apt-get install -y \
+    xubuntu-desktop
+
+# Add user
+RUN adduser blaster \
+      --gecos Blaster \
+      --disabled-password  \
+    && \
+    adduser blaster sudo \
+    && \
+    echo blaster:password | chpasswd
+
+# Editors, Linux, etc
+RUN apt-get install -y \
+  build-essential \
+  debconf-utils \
+  cmake \
+  autoconf \
+  automake \
+  libtool \
+  autoconf-archive \
+  autotools-dev \
+  emacs \
+  linux-headers-generic
+
+# virtualbox
+RUN apt-get install -y \
+  virtualbox-guest-utils \
+  virtualbox-guest-x11 \
+  virtualbox-guest-dkms
+
+
+# NTD packages
+RUN apt-get install -y  \
+  sbcl
+
+# Kernel stuff
+RUN apt-get install -y --download-only \
+  grub2 \
+  grub-pc \
+  linux-image-generic \
+  linux-headers-generic
+
+# Local Variables:
+# mode: dockerfile
+# End:


### PR DESCRIPTION
Here's a summary of my changes for this. 
Please advise if you would like any additions or deletions. 
Thanks!

--
Notes: 
1. `vbox-img` was a standalone tool released with Virtualbox 4, and not since. This updates that command to use `qemu-img`, which is similar syntax and identical function. 
2. There's no longer need to switch lightdm to gdm3. It works out of the box now
3. There seems to be a network misconfiguration out of the box. User needs to raise the interface with `# ip link set enp0s3 up` and then start `dhclient`